### PR TITLE
Fix stale import fixer status

### DIFF
--- a/Packages/SimbiKit/Sources/SimbiUI/ImportController.swift
+++ b/Packages/SimbiKit/Sources/SimbiUI/ImportController.swift
@@ -179,6 +179,8 @@ public final class ImportController {
                 failure = Self.failureMessage(for: error, fileName: fileName)
             }
             progressTask.cancel()
+            // Drain any delivered update before committing the final UI state.
+            await progressTask.value
             decodingAudio = false
             fixingTranscript = false
             status = failure.map { .failed(message: $0) } ?? .idle


### PR DESCRIPTION
## Summary

- wait for the cancelled import progress consumer to terminate
- commit the final idle or failed UI state only after queued progress updates are drained
- prevent a late fixing event from restoring the completed import indicator

Closes #4.

## Verification

- swift format lint passed
- Swift package build passed
- all 309 package tests passed
- Xcode Debug build passed
- launched the newly built app and verified the note UI